### PR TITLE
Bugfix on PDF Plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,7 @@ theme:
   #   - navigation.tabs
 plugins:
   - search
-  - with-pdf:
-      render_js: true
+  - with-pdf
   - mermaid2:
       version: 8.8.2
       arguments:


### PR DESCRIPTION
This fixes a mistake somewhere in the deployment due to non-existing headless browser in CI